### PR TITLE
Returning from a logging block is too aggressive.

### DIFF
--- a/lib/excon/rails.rb
+++ b/lib/excon/rails.rb
@@ -13,22 +13,22 @@ module Excon
       color ActiveSupport::LogSubscriber::BLUE
 
       event :request do |event|
-        return unless logger.debug?
+        next unless logger.debug?
         debug request_info(event)
       end
 
       event :response do |event|
-        return unless logger.debug?
+        next unless logger.debug?
         debug message(event, 'Excon Response', "#{status(event)} (#{length(event)})")
       end
 
       event :retry do |event|
-        return unless logger.debug?
+        next unless logger.debug?
         debug request_info(event)
       end
 
       event :error do |event|
-        return unless logger.info?
+        next unless logger.info?
         info message(event, 'Excon Error', event.payload[:error])
       end
 

--- a/spec/excon/rails_spec.rb
+++ b/spec/excon/rails_spec.rb
@@ -41,5 +41,14 @@ module Excon
       expect(@logger.logged(:debug)[0])
         .to match(%r{Excon Request \(\d+\.\d+ms\)  http://example\.com/})
     end
+
+    it 'omits debug logging in production' do
+      @logger.level = Logger::ERROR
+      Rails::Railtie.run_initializers
+      Excon.new('http://example.com').request
+      expect(@logger.logged(:debug)).to be_empty
+      expect(@logger.logged(:info)).to be_empty
+      expect(@logger.logged(:error)).to be_empty
+    end
   end
 end


### PR DESCRIPTION
I saw the following error messages in our log files:

ERROR -- : Could not log "request.excon" event. LocalJumpError: unexpected return [... stacktrace omitted ...]

Apparently returning from the block was too aggressive. Added a test to make sure that we're not logging anything we shouldn't. Before this fix, it failed for this exact reason.
